### PR TITLE
Update ppxlib>=0.36.0

### DIFF
--- a/ppx/ppx_lun.ml
+++ b/ppx/ppx_lun.ml
@@ -58,6 +58,7 @@ let lense_impl ~name ~uniq (ld : label_declaration) =
                [ (Nolabel, prj); (Nolabel, inj) ])
       ; pvb_attributes = []
       ; pvb_loc = loc
+      ; pvb_constraint = None
       }
     ]
 
@@ -87,7 +88,7 @@ let prism_impl ~name ~uniq (ctor : constructor_declaration) =
               [ (Nolabel, eunit ~loc) ]
           in
           let cases = [ case ~lhs ~guard:None ~rhs ] in
-          pexp_function ~loc
+          pexp_function_cases ~loc
             (if uniq then cases else List.rev (error_case ~loc :: cases))
         in
         (inj, prj)
@@ -123,7 +124,7 @@ let prism_impl ~name ~uniq (ctor : constructor_declaration) =
               ]
           in
           let cases = [ case ~lhs ~guard:None ~rhs ] in
-          pexp_function ~loc
+          pexp_function_cases ~loc
             (if uniq then cases else List.rev (error_case ~loc :: cases))
         in
         (inj, prj)
@@ -162,7 +163,7 @@ let prism_impl ~name ~uniq (ctor : constructor_declaration) =
               ]
           in
           let cases = [ case ~lhs ~guard:None ~rhs ] in
-          pexp_function ~loc
+          pexp_function_cases ~loc
             (if uniq then cases else List.rev (error_case ~loc :: cases))
         in
         (inj, prj)
@@ -178,6 +179,7 @@ let prism_impl ~name ~uniq (ctor : constructor_declaration) =
                [ (Nolabel, inj); (Nolabel, prj) ])
       ; pvb_attributes = []
       ; pvb_loc = loc
+      ; pvb_constraint = None
       }
     ]
 

--- a/ppx_lun.opam
+++ b/ppx_lun.opam
@@ -17,6 +17,6 @@ depends: [
   "ocaml" {>= "4.12.0"}
   "dune" {>= "3.5"}
   "lun" {= version}
-  "ppxlib" {>= "0.29.0"}
+  "ppxlib" {>= "0.36.0"}
   "fmt" {with-test}
 ]


### PR DESCRIPTION
I'm not fully confident these changes are correct. They were guided by compiler errors and this diff:
https://github.com/ocaml-ppx/ppxlib/commit/108ae3a607aef9c354e7e3194667bc2ea16a8c6d