### PR TITLE
Small extensions to the API

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,3 @@
 # The commit upgrading to ocamlformat.0.29.0
 118da35ebb3a0ea7581c234c7d3db7d989814a79
+e93d5a92896007bb04d87c82ec703b8e10d3afe5

--- a/src/lun.ml
+++ b/src/lun.ml
@@ -31,10 +31,8 @@ let get f t = (f ()).f (fun v _ -> v) t never
 let get_opt f t = (f ()).f (fun v _ -> Some v) t (Fun.const Option.none)
 let setf o ~f t = (o ()).f (fun a rf -> rf (f a)) t (fun r -> r)
 let set o v = setf o ~f:(fun _ -> v)
-
 let id () = lense Fun.id (fun _ x -> x)
 let ( >> ) f g () = { f = (fun z -> (f ()).f ((g ()).f z)) }
-
 let fst () = { f = (fun k (a, x) r -> k a (fun b -> r (b, x))) }
 let snd () = { f = (fun k (x, b) r -> k b (fun a -> r (x, a))) }
 
@@ -43,10 +41,13 @@ let some () =
   | Some x -> Result.ok x
   | None as x -> Result.error x
 
-let rec set_nth i l elt = match i, l with
+let rec set_nth i l elt =
+  match (i, l) with
   | _, [] -> []
   | 0, _h :: t -> elt :: t
-  | n, h :: t -> h :: set_nth (n-1) t elt
+  | n, h :: t -> h :: set_nth (n - 1) t elt
+
 let get_nth i l =
   match List.nth_opt l i with Some v -> v | None -> raise Undefined
+
 let nth i () = lense (get_nth i) (set_nth i)

--- a/src/lun.ml
+++ b/src/lun.ml
@@ -35,3 +35,11 @@ let some () =
   prism Option.some @@ function
   | Some x -> Result.ok x
   | None as x -> Result.error x
+
+let rec set_nth i l elt = match i, l with
+  | _, [] -> []
+  | 0, _h :: t -> elt :: t
+  | n, h :: t -> h :: set_nth (n-1) t elt
+let get_nth i l =
+  match List.nth_opt l i with Some v -> v | None -> raise Undefined
+let nth i () = lense (get_nth i) (set_nth i)

--- a/src/lun.ml
+++ b/src/lun.ml
@@ -24,7 +24,10 @@ let get f t = (f ()).f (fun v _ -> v) t never
 let get_opt f t = (f ()).f (fun v _ -> Some v) t (Fun.const Option.none)
 let setf o ~f t = (o ()).f (fun a rf -> rf (f a)) t (fun r -> r)
 let set o v = setf o ~f:(fun _ -> v)
+
+let id () = lense Fun.id (fun _ x -> x)
 let ( >> ) f g () = { f = (fun z -> (f ()).f ((g ()).f z)) }
+
 let fst () = { f = (fun k (a, x) r -> k a (fun b -> r (b, x))) }
 let snd () = { f = (fun k (x, b) r -> k b (fun a -> r (x, a))) }
 

--- a/src/lun.ml
+++ b/src/lun.ml
@@ -20,6 +20,13 @@ let prism f g =
   in
   { f }
 
+let optional f g =
+  let f k s r =
+    let ok x = k x (fun b -> r (f s b)) and error = r in
+    Result.fold (g s) ~error ~ok
+  in
+  { f }
+
 let get f t = (f ()).f (fun v _ -> v) t never
 let get_opt f t = (f ()).f (fun v _ -> Some v) t (Fun.const Option.none)
 let setf o ~f t = (o ()).f (fun a rf -> rf (f a)) t (fun r -> r)

--- a/src/lun.mli
+++ b/src/lun.mli
@@ -265,6 +265,9 @@ val prism : ('b -> 't) -> ('s -> ('a, 't) result) -> ('s, 't, 'a, 'b) s
       Lun.prism (fun n -> A n) @@ function A n -> Ok n | v -> Error v
     ]} *)
 
+val optional :
+  ('s -> 'b -> 't) -> ('s -> ('a, 't) result) -> ('s, 't, 'a, 'b) s
+
 exception Undefined
 (** An exception raised by {!val:get} when it's not possible to project a value
     with an optic. *)

--- a/src/lun.mli
+++ b/src/lun.mli
@@ -350,3 +350,4 @@ val id : ('a, 'b, 'a, 'b) t
 val fst : ('a * 'x, 'b * 'x, 'a, 'b) t
 val snd : ('x * 'a, 'x * 'b, 'a, 'b) t
 val some : ('a option, 'b option, 'a, 'b) t
+val nth : int -> ('a list, 'a list, 'a, 'a) t

--- a/src/lun.mli
+++ b/src/lun.mli
@@ -265,29 +265,25 @@ val prism : ('b -> 't) -> ('s -> ('a, 't) result) -> ('s, 't, 'a, 'b) s
       Lun.prism (fun n -> A n) @@ function A n -> Ok n | v -> Error v
     ]} *)
 
-val optional :
-  ('s -> 'b -> 't) -> ('s -> ('a, 't) result) -> ('s, 't, 'a, 'b) s
+val optional : ('s -> 'b -> 't) -> ('s -> ('a, 't) result) -> ('s, 't, 'a, 'b) s
 (** [optional inj prj] makes a new optic like {!val:prim} but the injection
     function take into account the current value that we would like to
     {!val:set}. For instance:
 
     {[
-      type t = A of int | B of int | C of int
+    type t = A of int | B of int | C of int
 
-      let optic () =
-        let inj prev n = match prev with
-          | A _ -> B n
-          | B _ -> C n
-          | C _ -> A n in
-        let prj = function A n | B n | C n -> Ok n in
-        Lun.optional inj prj
+    let optic () =
+      let inj prev n = match prev with A _ -> B n | B _ -> C n | C _ -> A n in
+      let prj = function A n | B n | C n -> Ok n in
+      Lun.optional inj prj
 
-      let () =
-        let v = A 0 |> Lun.set optic 1 |> Lun.set optic 2 |> Lun.set optic 3 in
-        (* A 0 -> B 1 -> C 2 -> A 3 *)
-        match v with
-        | A 3 -> assert true
-        | _   -> assert false
+    let () =
+      let v = A 0 |> Lun.set optic 1 |> Lun.set optic 2 |> Lun.set optic 3 in
+      (* A 0 -> B 1 -> C 2 -> A 3 *)
+      match v with
+      | A 3 -> assert true
+      | _ -> assert false
     ]} *)
 
 exception Undefined

--- a/src/lun.mli
+++ b/src/lun.mli
@@ -267,6 +267,28 @@ val prism : ('b -> 't) -> ('s -> ('a, 't) result) -> ('s, 't, 'a, 'b) s
 
 val optional :
   ('s -> 'b -> 't) -> ('s -> ('a, 't) result) -> ('s, 't, 'a, 'b) s
+(** [optional inj prj] makes a new optic like {!val:prim} but the injection
+    function take into account the current value that we would like to
+    {!val:set}. For instance:
+
+    {[
+      type t = A of int | B of int | C of int
+
+      let optic () =
+        let inj prev n = match prev with
+          | A _ -> B n
+          | B _ -> C n
+          | C _ -> A n in
+        let prj = function A n | B n | C n -> Ok n in
+        Lun.optional inj prj
+
+      let () =
+        let v = A 0 |> Lun.set optic 1 |> Lun.set optic 2 |> Lun.set optic 3 in
+        (* A 0 -> B 1 -> C 2 -> A 3 *)
+        match v with
+        | A 3 -> assert true
+        | _   -> assert false
+    ]} *)
 
 exception Undefined
 (** An exception raised by {!val:get} when it's not possible to project a value

--- a/src/lun.mli
+++ b/src/lun.mli
@@ -346,6 +346,7 @@ val ( >> ) : ('a, 'b, 'c, 'd) t -> ('c, 'd, 'e, 'f) t -> ('a, 'b, 'e, 'f) t
 
 (** Common lenses and prisms. *)
 
+val id : ('a, 'b, 'a, 'b) t
 val fst : ('a * 'x, 'b * 'x, 'a, 'b) t
 val snd : ('x * 'a, 'x * 'b, 'a, 'b) t
 val some : ('a option, 'b option, 'a, 'b) t


### PR DESCRIPTION
Provide several additions to the API:
- Some new common lenses: `id` the identity lense, and `nth` the lense which access the nth element of a list
- A new lense constructor, which contains both a setter and an optional getter. It exactly corresponds to optionally present fields.
