### PR TITLE
Lun patterns

### DIFF
--- a/ppx/ppx_lun.ml
+++ b/ppx/ppx_lun.ml
@@ -1,11 +1,18 @@
 open Ppxlib
 module List = ListLabels
 open Ast_builder.Default
+module H = Ast_helper
 
 let ( $. ) l x = Longident.Ldot (l, x)
 let lun = Longident.Lident "Lun"
 let unit = lident "unit"
 let str fmt = Format.kasprintf Fun.id fmt
+
+let attr_set_warning ~loc s =
+  attribute ~loc ~name:(Located.mk ~loc "warning")
+    ~payload:(PStr [pstr_eval ~loc (estring ~loc s) []])
+let set_warning s e =
+  H.Exp.attr e (attr_set_warning ~loc:e.pexp_loc s)
 
 let random_string ~len =
   let res = Bytes.create len in
@@ -299,3 +306,137 @@ let intf_generator = Deriving.Generator.V2.make_noarg generate_intf
 
 let my_deriver =
   Deriving.add "lun" ~str_type_decl:impl_generator ~sig_type_decl:intf_generator
+
+(** Pattern-based lun construction *)
+
+(** Return all the variables in a pattern. *)
+let find_vars =
+  let o = object
+    inherit [_] Ast_traverse.fold as super
+    method! pattern p acc =
+      match p.ppat_desc with
+      | Ppat_var l -> l :: acc
+      | _ -> super#pattern p acc
+  end
+  in fun p -> List.rev (o#pattern p [])
+
+(** Replace all the _ in a pattern by a variable. *)
+let rename_any_in_pat = object
+  inherit Ast_traverse.map as super
+  method! pattern p =
+    let loc = p.ppat_loc in
+    match p.ppat_desc with
+    | Ppat_any ->
+      {p with ppat_desc = Ppat_var (Located.mk ~loc @@ var "b")}
+    | _ -> super#pattern p
+end
+
+(** Replace the given variables by _ in a pattern. *)
+let erase_vars_in_pat set = object
+  inherit Ast_traverse.map as super
+  method! pattern p =
+    let loc = p.ppat_loc in
+    match p.ppat_desc with
+    | Ppat_var l when List.mem l.txt ~set -> ppat_any ~loc
+    | _ -> super#pattern p
+end
+
+let rec pat_to_constr p =
+  let loc = p.ppat_loc in
+  match p.ppat_desc with
+  (* Should have been removed by {!rename_any_in_pat} *)
+  | Ppat_any -> assert false
+  (* Valid cases *)
+  | Ppat_var v -> pexp_ident ~loc (Located.map_lident v)
+  | Ppat_tuple ps ->
+    let es = List.map ~f:pat_to_constr ps in
+    pexp_tuple ~loc es
+  | Ppat_construct (c, None) ->
+    pexp_construct ~loc c None
+  | Ppat_construct (c, Some (_,p)) ->
+    pexp_construct ~loc c (Some (pat_to_constr p))
+  | Ppat_variant (c, p) -> 
+    pexp_variant ~loc c (Option.map pat_to_constr p)
+  | Ppat_record (fields, Closed) ->
+    let fields = List.map ~f:(fun (l, p) -> l, pat_to_constr p) fields in
+    pexp_record ~loc fields None
+  | Ppat_array ps ->
+    let es = List.map ~f:pat_to_constr ps in
+    pexp_array ~loc es
+  | Ppat_extension ex ->
+    pexp_extension ~loc ex
+  (* Unsupported cases *)
+  | Ppat_record (_, Open)
+  | Ppat_alias (_, _)
+  | Ppat_constant _
+  | Ppat_interval (_, _)
+  | Ppat_or (_, _)
+  | Ppat_constraint  (_, _)
+  | Ppat_type _
+  | Ppat_lazy _
+  | Ppat_unpack _
+  | Ppat_exception _
+  | Ppat_open (_, _) ->
+    pexp_extension ~loc @@
+    Location.error_extensionf ~loc
+      "This feature is not supported in lun patterns"
+
+let optic_of_pattern ~ctxt pat guard =
+  let loc = Expansion_context.Extension.extension_point_loc ctxt in
+  let l = find_vars pat in
+  let prj =
+    let rhs =
+      pexp_apply ~loc
+        (pexp_ident ~loc { loc; txt = lident "Result" $. "ok" })
+        [Nolabel,
+         pexp_tuple ~loc
+           (List.map ~f:(fun v -> pexp_ident ~loc @@ Located.map_lident v) l)]
+    in
+    let c = case ~lhs:pat ~guard ~rhs in
+    H.Exp.function_
+      ~loc ~attrs:[attr_set_warning ~loc "-11"]
+      [ c ; error_case ~loc ]
+  in
+  let inj =
+    let varoutter = var "s" in
+    let p = rename_any_in_pat#pattern pat in
+    let e = pat_to_constr p in
+    let main_case =
+      let lhs = (erase_vars_in_pat @@ List.map ~f:Loc.txt l)#pattern p in
+      let rhs = e in
+      case ~lhs ~guard ~rhs
+    in
+    let id_case =
+      let lhs = ppat_any ~loc in
+      let rhs = evar ~loc varoutter in
+      case ~lhs ~guard:None ~rhs
+    in
+    pexp_function ~loc
+      [ pparam_val ~loc Nolabel None @@ pvar ~loc varoutter;
+        pparam_val ~loc Nolabel None @@
+        ppat_tuple ~loc @@ List.map ~f:(ppat_var ~loc) l ]
+      None
+      (Pfunction_body
+         (H.Exp.match_
+            ~loc ~attrs:[attr_set_warning ~loc "-11"]
+            (evar ~loc varoutter) [main_case; id_case]))
+  in
+  pexp_constraint ~loc
+    (pexp_fun ~loc Nolabel None (punit ~loc)
+       (pexp_apply ~loc
+          (pexp_ident ~loc { loc; txt = lun $. "optional" })
+          [ (Nolabel, inj); (Nolabel, prj) ]))
+    (ptyp_constr ~loc (Located.mk ~loc (lun $. "t")) [ptyp_any ~loc])
+
+let extracter () = Ast_pattern.(ppat __ __)
+
+let optic_pattern =
+  Extension.V3.declare "lun"
+    Extension.Context.expression
+    (extracter ())
+    optic_of_pattern
+
+let () =
+  Driver.register_transformation ~rules:[
+    Context_free.Rule.extension optic_pattern
+  ] "lun"

--- a/ppx/ppx_lun.ml
+++ b/ppx/ppx_lun.ml
@@ -363,20 +363,37 @@ let rec pat_to_constr p =
   | Ppat_array ps ->
     let es = List.map ~f:pat_to_constr ps in
     pexp_array ~loc es
+  | Ppat_constant c ->
+    pexp_constant ~loc c
+  | Ppat_constraint (p, ty) ->
+    pexp_constraint ~loc (pat_to_constr p) ty
+  | Ppat_open (l, p) ->
+    pexp_open ~loc (H.Opn.mk ~loc (pmod_ident ~loc l)) (pat_to_constr p)
+  | Ppat_alias (p', var) ->
+    let var = Located.map_lident var in
+    let vars = find_vars p' in
+    if List.is_empty vars then
+      pexp_ident ~loc var
+    else
+      let warning =
+        attribute_of_warning p'.ppat_loc
+          "Variables in a pattern under an alias are ignored"
+      in
+      H.Exp.ident ~attrs:[warning] ~loc var
+  | Ppat_or (p1, _) ->
+    pat_to_constr p1
   | Ppat_extension ex ->
     pexp_extension ~loc ex
   (* Unsupported cases *)
   | Ppat_record (_, Open)
-  | Ppat_alias (_, _)
-  | Ppat_constant _
-  | Ppat_interval (_, _)
-  | Ppat_or (_, _)
-  | Ppat_constraint  (_, _)
-  | Ppat_type _
+  | Ppat_interval (_, _) ->
+    pexp_extension ~loc @@
+    Location.error_extensionf ~loc
+      "This pattern has implicit open variables. Please use an alias to bind its content."
   | Ppat_lazy _
   | Ppat_unpack _
-  | Ppat_exception _
-  | Ppat_open (_, _) ->
+  | Ppat_type _
+  | Ppat_exception _ ->
     pexp_extension ~loc @@
     Location.error_extensionf ~loc
       "This feature is not supported in lun patterns"

--- a/ppx/ppx_lun.ml
+++ b/ppx/ppx_lun.ml
@@ -425,7 +425,7 @@ let tuple_of_list ~loc l = match l with
       (List.map ~f:(fun v -> pexp_ident ~loc @@ Located.map_lident v) l),
     ppat_tuple ~loc @@ List.map ~f:(ppat_var ~loc) l
 
-let mk_full_prj ~loc pat_outter guard expr_inner =
+let mk_total_prj ~loc pat_outter guard expr_inner =
   let guard =
     Option.map (fun g ->
         let loc = g.pexp_loc in
@@ -457,7 +457,7 @@ let mk_constructor ~loc pat_outter pat_inner =
     None
     (Pfunction_body rhs)
 
-let mk_full_setter ~loc pat_outter pat_inner captured_vars =
+let mk_total_setter ~loc pat_outter pat_inner captured_vars =
   let rhs = pat_to_constr pat_outter in
   let all_vars = List.map ~f:Loc.txt captured_vars in
   let lhs = (erase_vars_in_pat all_vars)#pattern pat_outter in
@@ -501,10 +501,10 @@ let lense_of_pattern ~ctxt pat guard =
   let loc = Expansion_context.Extension.extension_point_loc ctxt in
   let l = find_vars pat in
   let evars, pvars = tuple_of_list ~loc l in
-  let prj = mk_full_prj ~loc pat guard evars in
+  let prj = mk_total_prj ~loc pat guard evars in
   let inj =
     let p = alias_open_in_pat#pattern pat in
-    mk_full_setter ~loc p pvars l
+    mk_total_setter ~loc p pvars l
   in
   mk_from_prj_inj ~loc "lense" [prj; inj]
 
@@ -519,7 +519,7 @@ let prism_of_pattern ~ctxt pat guard =
   in
   mk_from_prj_inj ~loc "prism" [inj; prj]
 
-let optic_of_pattern ~ctxt pat guard =
+let optional_of_pattern ~ctxt pat guard =
   let loc = Expansion_context.Extension.extension_point_loc ctxt in
   let l = find_vars pat in
   let evars, pvars = tuple_of_list ~loc l in
@@ -530,27 +530,49 @@ let optic_of_pattern ~ctxt pat guard =
   in
   mk_from_prj_inj ~loc "optional" [inj; prj]
 
-let optic_pattern =
-  Extension.V3.declare "lun"
-    Extension.Context.expression
-    Ast_pattern.(ppat __ __)
-    optic_of_pattern
+(** Check if a pattern is a constructor, i.e., it doesn't have
+    open subpatterns. *)
+let is_constructor p = object
+  inherit [bool] Ast_traverse.fold as super
+  method! pattern p b =
+    match p.ppat_desc with
+    | Ppat_any | Ppat_record (_, Open) -> false
+    | _ -> super#pattern p b
+end#pattern p true
 
-let lense_pattern =
-  Extension.V3.declare "lun.lense"
-    Extension.Context.expression
-    Ast_pattern.(ppat __ __)
-    lense_of_pattern
+(** Check if a pattern is trivially total/irrefutable, i.e. it doesn't
+    have sum constructors.
+    This doesn't catch single sum types. *)
+let is_total p = object
+  inherit [bool] Ast_traverse.fold as super
+  method! pattern p b =
+    match p.ppat_desc with
+    | Ppat_constant _
+    | Ppat_interval _
+    | Ppat_construct _
+    | Ppat_variant _ -> false
+    | _ -> super#pattern p b
+end#pattern p true
 
-let prism_pattern =
-  Extension.V3.declare "lun.prism"
-    Extension.Context.expression
-    Ast_pattern.(ppat __ __)
-    prism_of_pattern
+let optics_of_pattern ~ctxt pat guard =
+  let constructor = is_constructor pat in
+  let total = is_total pat && Option.is_none guard in
+  match total, constructor with
+  | true, _ -> lense_of_pattern ~ctxt pat guard
+  | _, true -> prism_of_pattern ~ctxt pat guard
+  | false, false -> optional_of_pattern ~ctxt pat guard
 
 let () =
-  Driver.register_transformation ~rules:[
-    Context_free.Rule.extension optic_pattern;
-    Context_free.Rule.extension lense_pattern;
-    Context_free.Rule.extension prism_pattern;
-  ] "lun"
+  let rules =
+    List.map
+      ~f:(fun (s,f) ->
+          Context_free.Rule.extension @@
+          Extension.V3.declare s
+            Extension.Context.expression Ast_pattern.(ppat __ __) f)
+      [ "lun.lense", lense_of_pattern;
+        "lun.prism", prism_of_pattern;
+        "lun.optional", optional_of_pattern;
+        "lun", optics_of_pattern;
+      ]
+  in
+  Driver.register_transformation ~rules "lun"

--- a/ppx/ppx_lun.ml
+++ b/ppx/ppx_lun.ml
@@ -386,6 +386,8 @@ let rec pat_to_constr p =
           "Variables in a pattern under an alias are ignored"
       in
       H.Exp.ident ~attrs:[warning] ~loc var
+  | Ppat_lazy p ->
+    pexp_lazy ~loc (pat_to_constr p)
   | Ppat_interval (c, _) -> pexp_constant ~loc c
   | Ppat_or (p1, _) ->
     pat_to_constr p1
@@ -396,7 +398,6 @@ let rec pat_to_constr p =
     pexp_extension ~loc @@
     Location.error_extensionf ~loc
       "This pattern has implicit open variables. Please use an alias to bind its content."
-  | Ppat_lazy _
   | Ppat_unpack _
   | Ppat_type _
   | Ppat_exception _ ->

--- a/ppx/ppx_lun.ml
+++ b/ppx/ppx_lun.ml
@@ -404,16 +404,25 @@ let rec pat_to_constr p =
     Location.error_extensionf ~loc
       "This feature is not supported in lun patterns"
 
+let tuple_of_list ~loc l = match l with
+  | [] -> eunit ~loc, punit ~loc
+  | [x] ->
+    pexp_ident ~loc @@ Located.map_lident x,
+    ppat_var ~loc x
+  | l ->
+    pexp_tuple ~loc
+      (List.map ~f:(fun v -> pexp_ident ~loc @@ Located.map_lident v) l),
+    ppat_tuple ~loc @@ List.map ~f:(ppat_var ~loc) l
+
 let optic_of_pattern ~ctxt pat guard =
   let loc = Expansion_context.Extension.extension_point_loc ctxt in
   let l = find_vars pat in
+  let evars, pvars = tuple_of_list ~loc l in
   let prj =
     let rhs =
       pexp_apply ~loc
         (pexp_ident ~loc { loc; txt = lident "Result" $. "ok" })
-        [Nolabel,
-         pexp_tuple ~loc
-           (List.map ~f:(fun v -> pexp_ident ~loc @@ Located.map_lident v) l)]
+        [Nolabel, evars]
     in
     let c = case ~lhs:pat ~guard ~rhs in
     H.Exp.function_
@@ -436,8 +445,7 @@ let optic_of_pattern ~ctxt pat guard =
     in
     pexp_function ~loc
       [ pparam_val ~loc Nolabel None @@ pvar ~loc varoutter;
-        pparam_val ~loc Nolabel None @@
-        ppat_tuple ~loc @@ List.map ~f:(ppat_var ~loc) l ]
+        pparam_val ~loc Nolabel None @@ pvars ]
       None
       (Pfunction_body
          (H.Exp.match_

--- a/ppx/ppx_lun.ml
+++ b/ppx/ppx_lun.ml
@@ -386,13 +386,13 @@ let rec pat_to_constr p =
           "Variables in a pattern under an alias are ignored"
       in
       H.Exp.ident ~attrs:[warning] ~loc var
+  | Ppat_interval (c, _) -> pexp_constant ~loc c
   | Ppat_or (p1, _) ->
     pat_to_constr p1
   | Ppat_extension ex ->
     pexp_extension ~loc ex
   (* Unsupported cases *)
-  | Ppat_record (_, Open)
-  | Ppat_interval (_, _) ->
+  | Ppat_record (_, Open)->
     pexp_extension ~loc @@
     Location.error_extensionf ~loc
       "This pattern has implicit open variables. Please use an alias to bind its content."

--- a/ppx/ppx_lun.ml
+++ b/ppx/ppx_lun.ml
@@ -330,7 +330,7 @@ let rename_open_in_pat = object
     | Ppat_any ->
       {p with ppat_desc = Ppat_var var}
     | Ppat_record (_, Open) ->
-      ppat_alias ~loc p var
+      ppat_alias ~loc (super#pattern p) var
     | _ -> super#pattern p
 end
 

--- a/ppx/ppx_lun.ml
+++ b/ppx/ppx_lun.ml
@@ -320,14 +320,17 @@ let find_vars =
   end
   in fun p -> List.rev (o#pattern p [])
 
-(** Replace all the _ in a pattern by a variable. *)
-let rename_any_in_pat = object
+(** Replace all open patterns by a variable. *)
+let rename_open_in_pat = object
   inherit Ast_traverse.map as super
   method! pattern p =
     let loc = p.ppat_loc in
+    let var = Located.mk ~loc @@ var "b" in
     match p.ppat_desc with
     | Ppat_any ->
-      {p with ppat_desc = Ppat_var (Located.mk ~loc @@ var "b")}
+      {p with ppat_desc = Ppat_var var}
+    | Ppat_record (_, Open) ->
+      ppat_alias ~loc p var
     | _ -> super#pattern p
 end
 
@@ -360,6 +363,9 @@ let rec pat_to_constr p =
   | Ppat_record (fields, Closed) ->
     let fields = List.map ~f:(fun (l, p) -> l, pat_to_constr p) fields in
     pexp_record ~loc fields None
+  | Ppat_alias ({ppat_desc = Ppat_record (fields, Open); _}, v) ->
+    let fields = List.map ~f:(fun (l, p) -> l, pat_to_constr p) fields in
+    pexp_record ~loc fields (Some (pexp_ident ~loc @@ Located.map_lident v))
   | Ppat_array ps ->
     let es = List.map ~f:pat_to_constr ps in
     pexp_array ~loc es
@@ -416,7 +422,7 @@ let optic_of_pattern ~ctxt pat guard =
   in
   let inj =
     let varoutter = var "s" in
-    let p = rename_any_in_pat#pattern pat in
+    let p = rename_open_in_pat#pattern pat in
     let e = pat_to_constr p in
     let main_case =
       let lhs = (erase_vars_in_pat @@ List.map ~f:Loc.txt l)#pattern p in

--- a/ppx/ppx_lun.ml
+++ b/ppx/ppx_lun.ml
@@ -415,86 +415,92 @@ let tuple_of_list ~loc l = match l with
       (List.map ~f:(fun v -> pexp_ident ~loc @@ Located.map_lident v) l),
     ppat_tuple ~loc @@ List.map ~f:(ppat_var ~loc) l
 
-
-let lense_of_pattern ~ctxt pat guard =
+let mk_full_prj ~loc pat_outter guard expr_inner =
   let guard =
     Option.map (fun g ->
         let loc = g.pexp_loc in
         pexp_extension ~loc @@
         Location.error_extensionf ~loc
-          "Lenses should be total, guards are not allowed. Use a full lun pattern."
+          "This optic was expected to be total. To use guards, use a full lun pattern instead."
       ) guard
-  in        
-  let loc = Expansion_context.Extension.extension_point_loc ctxt in
-  let l = find_vars pat in
-  let evars, pvars = tuple_of_list ~loc l in
-  let prj =
-    let rhs = evars in
-    let c = case ~lhs:pat ~guard ~rhs in
-    H.Exp.function_ ~loc [ c ]
   in
-  let inj =
-    let p = rename_open_in_pat#pattern pat in
-    let rhs = pat_to_constr p in
-    let all_vars = List.map ~f:Loc.txt l in
-    let lhs = (erase_vars_in_pat all_vars)#pattern p in
-    pexp_function ~loc
-      [ pparam_val ~loc Nolabel None @@ lhs;
-        pparam_val ~loc Nolabel None @@ pvars ]
-      None
-      (Pfunction_body rhs)
+  let lhs = pat_outter in
+  let rhs = expr_inner in
+  H.Exp.function_ ~loc [ case ~lhs ~guard ~rhs ]
+
+let mk_partial_prj ~loc pat_outter guard expr_inner =
+  let lhs = pat_outter in
+  let rhs =
+    pexp_apply ~loc
+      (pexp_ident ~loc { loc; txt = lident "Result" $. "ok" })
+      [Nolabel, expr_inner]
   in
+  H.Exp.function_
+    ~loc ~attrs:[attr_set_warning ~loc "-11"]
+    [ case ~lhs ~guard ~rhs ;
+      error_case ~loc ]
+
+let mk_full_setter ~loc pat_outter pat_inner captured_vars =
+  let rhs = pat_to_constr pat_outter in
+  let all_vars = List.map ~f:Loc.txt captured_vars in
+  let lhs = (erase_vars_in_pat all_vars)#pattern pat_outter in
+  pexp_function ~loc
+    [ pparam_val ~loc Nolabel None @@ lhs;
+      pparam_val ~loc Nolabel None @@ pat_inner ]
+    None
+    (Pfunction_body rhs)
+
+let mk_partial_setter ~loc pat_outter guard pat_inner captured_vars =
+  let varoutter = var "s" in
+  let all_vars = List.map ~f:Loc.txt captured_vars in
+  let main_case =
+    let lhs = (erase_vars_in_pat all_vars)#pattern pat_outter in
+    let rhs = pat_to_constr pat_outter in
+    case ~lhs ~guard ~rhs
+  in
+  let id_case =
+    let lhs = ppat_any ~loc in
+    let rhs = evar ~loc varoutter in
+    case ~lhs ~guard:None ~rhs
+  in
+  pexp_function ~loc
+    [ pparam_val ~loc Nolabel None @@ pvar ~loc varoutter;
+      pparam_val ~loc Nolabel None @@ pat_inner ]
+    None
+    (Pfunction_body
+       (H.Exp.match_
+          ~loc ~attrs:[attr_set_warning ~loc "-11"]
+          (evar ~loc varoutter) [main_case; id_case]))
+
+let mk_from_prj_inj ~loc lun_builder ~prj ~inj = 
   pexp_constraint ~loc
     (pexp_fun ~loc Nolabel None (punit ~loc)
        (pexp_apply ~loc
-          (pexp_ident ~loc { loc; txt = lun $. "lense" })
+          (pexp_ident ~loc { loc; txt = lun $. lun_builder })
           [ (Nolabel, prj) ; (Nolabel, inj) ]))
     (ptyp_constr ~loc (Located.mk ~loc (lun $. "t")) [ptyp_any ~loc])
+
+let lense_of_pattern ~ctxt pat guard =
+  let loc = Expansion_context.Extension.extension_point_loc ctxt in
+  let l = find_vars pat in
+  let evars, pvars = tuple_of_list ~loc l in
+  let prj = mk_full_prj ~loc pat guard evars in
+  let inj =
+    let p = rename_open_in_pat#pattern pat in
+    mk_full_setter ~loc p pvars l
+  in
+  mk_from_prj_inj ~loc "lense" ~prj ~inj
 
 let optic_of_pattern ~ctxt pat guard =
   let loc = Expansion_context.Extension.extension_point_loc ctxt in
   let l = find_vars pat in
   let evars, pvars = tuple_of_list ~loc l in
-  let prj =
-    let rhs =
-      pexp_apply ~loc
-        (pexp_ident ~loc { loc; txt = lident "Result" $. "ok" })
-        [Nolabel, evars]
-    in
-    let c = case ~lhs:pat ~guard ~rhs in
-    H.Exp.function_
-      ~loc ~attrs:[attr_set_warning ~loc "-11"]
-      [ c ; error_case ~loc ]
-  in
+  let prj = mk_partial_prj ~loc pat guard evars in
   let inj =
-    let varoutter = var "s" in
     let p = rename_open_in_pat#pattern pat in
-    let e = pat_to_constr p in
-    let main_case =
-      let lhs = (erase_vars_in_pat @@ List.map ~f:Loc.txt l)#pattern p in
-      let rhs = e in
-      case ~lhs ~guard ~rhs
-    in
-    let id_case =
-      let lhs = ppat_any ~loc in
-      let rhs = evar ~loc varoutter in
-      case ~lhs ~guard:None ~rhs
-    in
-    pexp_function ~loc
-      [ pparam_val ~loc Nolabel None @@ pvar ~loc varoutter;
-        pparam_val ~loc Nolabel None @@ pvars ]
-      None
-      (Pfunction_body
-         (H.Exp.match_
-            ~loc ~attrs:[attr_set_warning ~loc "-11"]
-            (evar ~loc varoutter) [main_case; id_case]))
+    mk_partial_setter ~loc p guard pvars l
   in
-  pexp_constraint ~loc
-    (pexp_fun ~loc Nolabel None (punit ~loc)
-       (pexp_apply ~loc
-          (pexp_ident ~loc { loc; txt = lun $. "optional" })
-          [ (Nolabel, inj); (Nolabel, prj) ]))
-    (ptyp_constr ~loc (Located.mk ~loc (lun $. "t")) [ptyp_any ~loc])
+  mk_from_prj_inj ~loc "optional" ~prj ~inj
 
 let optic_pattern =
   Extension.V3.declare "lun"

--- a/ppx/ppx_lun.ml
+++ b/ppx/ppx_lun.ml
@@ -320,19 +320,30 @@ let find_vars =
   end
   in fun p -> List.rev (o#pattern p [])
 
-(** Replace all open patterns by a variable. *)
-let rename_open_in_pat = object
+(** Replace all open patterns. *)
+let map_open_in_pat f = object
   inherit Ast_traverse.map as super
   method! pattern p =
     let loc = p.ppat_loc in
-    let var = Located.mk ~loc @@ var "b" in
     match p.ppat_desc with
-    | Ppat_any ->
-      {p with ppat_desc = Ppat_var var}
+    | Ppat_any
     | Ppat_record (_, Open) ->
-      ppat_alias ~loc (super#pattern p) var
+      f ~loc (super#pattern p)
     | _ -> super#pattern p
 end
+(* Replace by a variable. *)
+let alias_open_in_pat =
+  map_open_in_pat (fun ~loc p ->
+      let var = Located.mk ~loc @@ var "b" in
+      ppat_alias ~loc p var
+    )
+(* Replace by an error. *)
+let forbid_open_in_pat = 
+  map_open_in_pat (fun ~loc _p ->
+      ppat_extension ~loc @@
+      Location.error_extensionf ~loc
+        "This optic is expected to bind its full content. To use open patterns, use a full lun pattern instead. "
+    )
 
 (** Replace the given variables by _ in a pattern. *)
 let erase_vars_in_pat set = object
@@ -347,8 +358,6 @@ end
 let rec pat_to_constr p =
   let loc = p.ppat_loc in
   match p.ppat_desc with
-  (* Should have been removed by {!rename_any_in_pat} *)
-  | Ppat_any -> assert false
   (* Valid cases *)
   | Ppat_var v -> pexp_ident ~loc (Located.map_lident v)
   | Ppat_tuple ps ->
@@ -394,6 +403,7 @@ let rec pat_to_constr p =
   | Ppat_extension ex ->
     pexp_extension ~loc ex
   (* Unsupported cases *)
+  | Ppat_any
   | Ppat_record (_, Open)->
     pexp_extension ~loc @@
     Location.error_extensionf ~loc
@@ -421,7 +431,7 @@ let mk_full_prj ~loc pat_outter guard expr_inner =
         let loc = g.pexp_loc in
         pexp_extension ~loc @@
         Location.error_extensionf ~loc
-          "This optic was expected to be total. To use guards, use a full lun pattern instead."
+          "This optic is expected to be total. To use guards, use a full lun pattern instead."
       ) guard
   in
   let lhs = pat_outter in
@@ -439,6 +449,13 @@ let mk_partial_prj ~loc pat_outter guard expr_inner =
     ~loc ~attrs:[attr_set_warning ~loc "-11"]
     [ case ~lhs ~guard ~rhs ;
       error_case ~loc ]
+
+let mk_constructor ~loc pat_outter pat_inner = 
+  let rhs = pat_to_constr pat_outter in
+  pexp_function ~loc
+    [ pparam_val ~loc Nolabel None @@ pat_inner ]
+    None
+    (Pfunction_body rhs)
 
 let mk_full_setter ~loc pat_outter pat_inner captured_vars =
   let rhs = pat_to_constr pat_outter in
@@ -472,12 +489,12 @@ let mk_partial_setter ~loc pat_outter guard pat_inner captured_vars =
           ~loc ~attrs:[attr_set_warning ~loc "-11"]
           (evar ~loc varoutter) [main_case; id_case]))
 
-let mk_from_prj_inj ~loc lun_builder ~prj ~inj = 
+let mk_from_prj_inj ~loc lun_builder args = 
   pexp_constraint ~loc
     (pexp_fun ~loc Nolabel None (punit ~loc)
        (pexp_apply ~loc
           (pexp_ident ~loc { loc; txt = lun $. lun_builder })
-          [ (Nolabel, prj) ; (Nolabel, inj) ]))
+          (List.map ~f:(fun f -> Nolabel, f) args)))
     (ptyp_constr ~loc (Located.mk ~loc (lun $. "t")) [ptyp_any ~loc])
 
 let lense_of_pattern ~ctxt pat guard =
@@ -486,10 +503,21 @@ let lense_of_pattern ~ctxt pat guard =
   let evars, pvars = tuple_of_list ~loc l in
   let prj = mk_full_prj ~loc pat guard evars in
   let inj =
-    let p = rename_open_in_pat#pattern pat in
+    let p = alias_open_in_pat#pattern pat in
     mk_full_setter ~loc p pvars l
   in
-  mk_from_prj_inj ~loc "lense" ~prj ~inj
+  mk_from_prj_inj ~loc "lense" [prj; inj]
+
+let prism_of_pattern ~ctxt pat guard =
+  let loc = Expansion_context.Extension.extension_point_loc ctxt in
+  let l = find_vars pat in
+  let evars, pvars = tuple_of_list ~loc l in
+  let prj = mk_partial_prj ~loc pat guard evars in
+  let inj =
+    let p = forbid_open_in_pat#pattern pat in
+    mk_constructor ~loc p pvars
+  in
+  mk_from_prj_inj ~loc "prism" [inj; prj]
 
 let optic_of_pattern ~ctxt pat guard =
   let loc = Expansion_context.Extension.extension_point_loc ctxt in
@@ -497,10 +525,10 @@ let optic_of_pattern ~ctxt pat guard =
   let evars, pvars = tuple_of_list ~loc l in
   let prj = mk_partial_prj ~loc pat guard evars in
   let inj =
-    let p = rename_open_in_pat#pattern pat in
+    let p = alias_open_in_pat#pattern pat in
     mk_partial_setter ~loc p guard pvars l
   in
-  mk_from_prj_inj ~loc "optional" ~prj ~inj
+  mk_from_prj_inj ~loc "optional" [inj; prj]
 
 let optic_pattern =
   Extension.V3.declare "lun"
@@ -514,8 +542,15 @@ let lense_pattern =
     Ast_pattern.(ppat __ __)
     lense_of_pattern
 
+let prism_pattern =
+  Extension.V3.declare "lun.prism"
+    Extension.Context.expression
+    Ast_pattern.(ppat __ __)
+    prism_of_pattern
+
 let () =
   Driver.register_transformation ~rules:[
     Context_free.Rule.extension optic_pattern;
     Context_free.Rule.extension lense_pattern;
+    Context_free.Rule.extension prism_pattern;
   ] "lun"

--- a/ppx/ppx_lun.ml
+++ b/ppx/ppx_lun.ml
@@ -415,6 +415,42 @@ let tuple_of_list ~loc l = match l with
       (List.map ~f:(fun v -> pexp_ident ~loc @@ Located.map_lident v) l),
     ppat_tuple ~loc @@ List.map ~f:(ppat_var ~loc) l
 
+
+let lense_of_pattern ~ctxt pat guard =
+  let guard =
+    Option.map (fun g ->
+        let loc = g.pexp_loc in
+        pexp_extension ~loc @@
+        Location.error_extensionf ~loc
+          "Lenses should be total, guards are not allowed. Use a full lun pattern."
+      ) guard
+  in        
+  let loc = Expansion_context.Extension.extension_point_loc ctxt in
+  let l = find_vars pat in
+  let evars, pvars = tuple_of_list ~loc l in
+  let prj =
+    let rhs = evars in
+    let c = case ~lhs:pat ~guard ~rhs in
+    H.Exp.function_ ~loc [ c ]
+  in
+  let inj =
+    let p = rename_open_in_pat#pattern pat in
+    let rhs = pat_to_constr p in
+    let all_vars = List.map ~f:Loc.txt l in
+    let lhs = (erase_vars_in_pat all_vars)#pattern p in
+    pexp_function ~loc
+      [ pparam_val ~loc Nolabel None @@ lhs;
+        pparam_val ~loc Nolabel None @@ pvars ]
+      None
+      (Pfunction_body rhs)
+  in
+  pexp_constraint ~loc
+    (pexp_fun ~loc Nolabel None (punit ~loc)
+       (pexp_apply ~loc
+          (pexp_ident ~loc { loc; txt = lun $. "lense" })
+          [ (Nolabel, prj) ; (Nolabel, inj) ]))
+    (ptyp_constr ~loc (Located.mk ~loc (lun $. "t")) [ptyp_any ~loc])
+
 let optic_of_pattern ~ctxt pat guard =
   let loc = Expansion_context.Extension.extension_point_loc ctxt in
   let l = find_vars pat in
@@ -460,15 +496,20 @@ let optic_of_pattern ~ctxt pat guard =
           [ (Nolabel, inj); (Nolabel, prj) ]))
     (ptyp_constr ~loc (Located.mk ~loc (lun $. "t")) [ptyp_any ~loc])
 
-let extracter () = Ast_pattern.(ppat __ __)
-
 let optic_pattern =
   Extension.V3.declare "lun"
     Extension.Context.expression
-    (extracter ())
+    Ast_pattern.(ppat __ __)
     optic_of_pattern
+
+let lense_pattern =
+  Extension.V3.declare "lun.lense"
+    Extension.Context.expression
+    Ast_pattern.(ppat __ __)
+    lense_of_pattern
 
 let () =
   Driver.register_transformation ~rules:[
-    Context_free.Rule.extension optic_pattern
+    Context_free.Rule.extension optic_pattern;
+    Context_free.Rule.extension lense_pattern;
   ] "lun"

--- a/ppx_test/dune
+++ b/ppx_test/dune
@@ -7,8 +7,8 @@
  (package ppx_lun))
 
 (tests
- (names readme)
- (modules readme)
+ (names readme patterns)
+ (modules readme patterns)
  (preprocess
   (pps ppx_lun))
  (package ppx_lun))

--- a/ppx_test/dune
+++ b/ppx_test/dune
@@ -1,14 +1,14 @@
 (tests
- (names basic)
- (modules basic)
+ (names basic patterns)
+ (modules basic patterns)
  (libraries fmt)
  (preprocess
   (pps ppx_lun))
  (package ppx_lun))
 
 (tests
- (names readme patterns)
- (modules readme patterns)
+ (names readme)
+ (modules readme)
  (preprocess
   (pps ppx_lun))
  (package ppx_lun))

--- a/ppx_test/patterns.ml
+++ b/ppx_test/patterns.ml
@@ -12,7 +12,7 @@ let () =
   Fmt.pr "%d\n" (get [%lun? {foo; _}] v) ;
   Fmt.pr "%s\n" (get [%lun? {bar; foo = _}] v) ;
   let v = { nested = v; baz = 0.1 } in
-  Fmt.pr "%d\n" (get [%lun? {nested = { foo ; _}; baz = _}] v) ;
+  Fmt.pr "%d\n" (get [%lun? {nested = { foo ; _}; _}] v) ;
   Fmt.pr "%f\n" (get [%lun? {baz; _}] v) ;
   assert (get [%lun? A] A = ()) ;
   assert (get [%lun? B(x,y)] (B (1, 2)) = (1, 2)) ;

--- a/ppx_test/patterns.ml
+++ b/ppx_test/patterns.ml
@@ -19,16 +19,18 @@ let () =
   Fmt.pr "%f\n" (get [%lun.lense? {baz; _}] v) ;
   Fmt.pr "%f\n" (get [%lun? {baz; _}] v) ;
   assert (get [%lun.lense? A] A = ()) ;
+  assert (get [%lun.prism? A] A = ()) ;
   assert (get [%lun? A] A = ()) ;
   assert (get [%lun.lense? B(x,y)] (B (1, 2)) = (1, 2)) ;
+  assert (get [%lun.prism? B(x,y)] (B (1, 2)) = (1, 2)) ;
   assert (get [%lun? B(x,y)] (B (1, 2)) = (1, 2)) ;
   assert (get [%lun.lense? C x] (C (1, 2)) = (1, 2)) ;
   assert (get [%lun? C x] (C (1, 2)) = (1, 2)) ;
-  assert (get [%lun.lense? X] X = ()) ;
+  assert (get [%lun.prism? X] X = ()) ;
   assert (get [%lun? X] X = ()) ;
   assert (get_opt [%lun? Y] X = None) ;
   assert (get_opt [%lun? Z] Z = Some ()) ;
-  Fmt.pr "%d\n" (get [%lun? B(x,_)] (B (1, 2))) ;
+  Fmt.pr "%d\n" (get [%lun? B(x,_) when x < 4] (B (1, 2))) ;
   Fmt.pr "%d\n" (get [%lun? B(_,x)] (B (1, 2))) ;
   let v0 = { v = 0 } in
   let v1 = setf ~f:succ [%lun? {v}] v0 in
@@ -37,3 +39,8 @@ let () =
   v1.v <- 2 ;
   assert (v0.v = 0) ;
   assert (v1.v = 2)
+
+let _errors = 
+  let open Lun in
+  assert (get [%lun.lense? X] X = ()) ;
+  Fmt.pr "%d\n" (get [%lun.prism? B(x,_)] (B (1, 2))) ;

--- a/ppx_test/patterns.ml
+++ b/ppx_test/patterns.ml
@@ -1,11 +1,31 @@
-type t =
-  | Add of t * t
-  | Int of int
+type t = { foo: int; bar: string }
+type n = { nested: t; baz: float }
+type a = A
+type b = B of int * int
+type c = C of (int * int)
+type u = X | Y | Z
+type v = { mutable v: int }
 
-let f = [%lun? Add (x, y)]
-
-let e = [%lun? Add (_, Int v) when v > 10]
-
-type x = { x : int }
-
-let x = [%lun? { x }]
+let () =
+  let open Lun in
+  let v = { foo = 42; bar = "Hello World!" } in
+  Fmt.pr "%d\n" (get [%lun? {foo; _}] v) ;
+  Fmt.pr "%s\n" (get [%lun? {bar; foo = _}] v) ;
+  let v = { nested = v; baz = 0.1 } in
+  Fmt.pr "%d\n" (get [%lun? {nested = { foo ; _}; baz = _}] v) ;
+  Fmt.pr "%f\n" (get [%lun? {baz; _}] v) ;
+  assert (get [%lun? A] A = ()) ;
+  assert (get [%lun? B(x,y)] (B (1, 2)) = (1, 2)) ;
+  assert (get [%lun? C x] (C (1, 2)) = (1, 2)) ;
+  assert (get [%lun? X] X = ()) ;
+  assert (get_opt [%lun? Y] X = None) ;
+  assert (get_opt [%lun? Z] Z = Some ()) ;
+  Fmt.pr "%d\n" (get [%lun? B(x,_)] (B (1, 2))) ;
+  Fmt.pr "%d\n" (get [%lun? B(_,x)] (B (1, 2))) ;
+  let v0 = { v = 0 } in
+  let v1 = setf ~f:succ [%lun? {v}] v0 in
+  assert (v0.v = 0) ;
+  assert (v1.v = 1) ;
+  v1.v <- 2 ;
+  assert (v0.v = 0) ;
+  assert (v1.v = 2)

--- a/ppx_test/patterns.ml
+++ b/ppx_test/patterns.ml
@@ -1,0 +1,11 @@
+type t =
+  | Add of t * t
+  | Int of int
+
+let f = [%lun? Add (x, y)]
+
+let e = [%lun? Add (_, Int v) when v > 10]
+
+type x = { x : int }
+
+let x = [%lun? { x }]

--- a/ppx_test/patterns.ml
+++ b/ppx_test/patterns.ml
@@ -9,14 +9,22 @@ type v = { mutable v: int }
 let () =
   let open Lun in
   let v = { foo = 42; bar = "Hello World!" } in
+  Fmt.pr "%d\n" (get [%lun.lense? {foo; _}] v) ;
   Fmt.pr "%d\n" (get [%lun? {foo; _}] v) ;
+  Fmt.pr "%s\n" (get [%lun.lense? {bar; foo = _}] v) ;
   Fmt.pr "%s\n" (get [%lun? {bar; foo = _}] v) ;
   let v = { nested = v; baz = 0.1 } in
+  Fmt.pr "%d\n" (get [%lun.lense? {nested = { foo ; _}; _}] v) ;
   Fmt.pr "%d\n" (get [%lun? {nested = { foo ; _}; _}] v) ;
+  Fmt.pr "%f\n" (get [%lun.lense? {baz; _}] v) ;
   Fmt.pr "%f\n" (get [%lun? {baz; _}] v) ;
+  assert (get [%lun.lense? A] A = ()) ;
   assert (get [%lun? A] A = ()) ;
+  assert (get [%lun.lense? B(x,y)] (B (1, 2)) = (1, 2)) ;
   assert (get [%lun? B(x,y)] (B (1, 2)) = (1, 2)) ;
+  assert (get [%lun.lense? C x] (C (1, 2)) = (1, 2)) ;
   assert (get [%lun? C x] (C (1, 2)) = (1, 2)) ;
+  assert (get [%lun.lense? X] X = ()) ;
   assert (get [%lun? X] X = ()) ;
   assert (get_opt [%lun? Y] X = None) ;
   assert (get_opt [%lun? Z] Z = Some ()) ;

--- a/src/lun.ml
+++ b/src/lun.ml
@@ -35,3 +35,11 @@ let some () =
   prism Option.some @@ function
   | Some x -> Result.ok x
   | None as x -> Result.error x
+
+let rec set_nth i l elt = match i, l with
+  | _, [] -> []
+  | 0, _h :: t -> elt :: t
+  | n, h :: t -> h :: set_nth (n-1) t elt
+let get_nth i l =
+  match List.nth_opt l i with Some v -> v | None -> raise Undefined
+let nth i () = lense (get_nth i) (set_nth i)

--- a/src/lun.ml
+++ b/src/lun.ml
@@ -24,7 +24,10 @@ let get f t = (f ()).f (fun v _ -> v) t never
 let get_opt f t = (f ()).f (fun v _ -> Some v) t (Fun.const Option.none)
 let setf o ~f t = (o ()).f (fun a rf -> rf (f a)) t (fun r -> r)
 let set o v = setf o ~f:(fun _ -> v)
+
+let id () = lense Fun.id (fun _ x -> x)
 let ( >> ) f g () = { f = (fun z -> (f ()).f ((g ()).f z)) }
+
 let fst () = { f = (fun k (a, x) r -> k a (fun b -> r (b, x))) }
 let snd () = { f = (fun k (x, b) r -> k b (fun a -> r (x, a))) }
 

--- a/src/lun.ml
+++ b/src/lun.ml
@@ -20,6 +20,13 @@ let prism f g =
   in
   { f }
 
+let optional f g =
+  let f k s r =
+    let ok x = k x (fun b -> r (f s b)) and error = r in
+    Result.fold (g s) ~error ~ok
+  in
+  { f }
+
 let get f t = (f ()).f (fun v _ -> v) t never
 let get_opt f t = (f ()).f (fun v _ -> Some v) t (Fun.const Option.none)
 let setf o ~f t = (o ()).f (fun a rf -> rf (f a)) t (fun r -> r)

--- a/src/lun.mli
+++ b/src/lun.mli
@@ -356,3 +356,4 @@ val id : ('a, 'b, 'a, 'b) t
 val fst : ('a * 'x, 'b * 'x, 'a, 'b) t
 val snd : ('x * 'a, 'x * 'b, 'a, 'b) t
 val some : ('a option, 'b option, 'a, 'b) t
+val nth : int -> ('a list, 'a list, 'a, 'a) t

--- a/src/lun.mli
+++ b/src/lun.mli
@@ -352,6 +352,7 @@ val ( >> ) : ('a, 'b, 'c, 'd) t -> ('c, 'd, 'e, 'f) t -> ('a, 'b, 'e, 'f) t
 
 (** Common lenses and prisms. *)
 
+val id : ('a, 'b, 'a, 'b) t
 val fst : ('a * 'x, 'b * 'x, 'a, 'b) t
 val snd : ('x * 'a, 'x * 'b, 'a, 'b) t
 val some : ('a option, 'b option, 'a, 'b) t

--- a/src/lun.mli
+++ b/src/lun.mli
@@ -271,6 +271,9 @@ val prism : ('b -> 't) -> ('s -> ('a, 't) result) -> ('s, 't, 'a, 'b) s
         | v -> Error v
     ]} *)
 
+val optional :
+  ('s -> 'b -> 't) -> ('s -> ('a, 't) result) -> ('s, 't, 'a, 'b) s
+
 exception Undefined
 (** An exception raised by {!val:get} when it's not possible to project a value
     with an optic. *)


### PR DESCRIPTION
This PR introduces *Lun patterns* in the PPX which allow to build a lense based on a pattern.

For instance:
```ocaml
type t = Add of t list | Int of int

let x : (t, t, int * t, int * t) Lun.t = [%lun? Add [Int x; _; y]]
```

This code will give you an (optional) lense that extract the couple `(x,y)` from the given pattern.

It desugars to the following code:
```ocaml
(fun () ->
     Lun.optional
       (fun sSFzrMf (x, y) ->
          match[@warning "-11"] sSFzrMf with
            | Add ((Int _)::b1QecW4::_::[]) -> Add [Int x; b1QecW4; y]
            | _ -> sSFzrMf
          )
       (function[@warning "-11"]
         | Add ((Int x)::_::y::[]) -> Result.ok (x, y)
         | v -> Result.error v)
   : _ Lun.t)
```
It uses `Lun.optional` introduced by https://github.com/robur-coop/lun/pull/5 , so the first 3 commits come from there.

It supports :
- guards : `[%lun? Int x when x > 42]`
- Any number of variables (including zero): `[%lun? None]` or `[%lun? Add [a;b;c;d]`
- All syntactic patterns features, for instance punning `[%lun? {x}]`
- or patterns (with a left-leaning priority) `[%lun? Add [Int x; y] | Add [y; Int x]]`.
- All patterns without implicitly open patterns
- Some work was done to make merlin behaves reasonably, and locate the error/warnings appropriately
- ~~Some~~ All patterns with open variables: `[lun? {x; y; _}]`

It forbids:
- Patterns with nested variables/aliases: `[lun? Some (Add [x] as y)]`.
  I'm not sure how to write a reasonable setter there.
- ~~lazy~~, module and exception patterns

Things that might still be improved:
- [x] ~~Nested open patterns are not really supported, for instance `[%lun? {x = {y ; _}; _}]`. It's not obvious how to implement that cleanly. However when "expanded" by making all outer fields concrete, it will work.~~ Fixed
- [x] ~~The current version always make an `optional` lun. It could be desirable to propose functions to only build lenses and prisms (and verify it). It could also be useful to inspect the patterns to check if it's a lense/prism, and simplify the emitted code.~~ It now outputs a level appropriate to the pattern.
- [ ] Currently, a lun pattern always build the tuple of all the variables. We could easily introduce an output *constructor*, for instance : `[%lun? Add (x, y) -> { left = x ; right = y }]`. There would be constraints on the right-hand side (typically, that it can be turned into a pattern), but that shouldn't be too difficult. The main issue would really be the syntax, in fact.

For context, the reason I built this, is that I wanted to provide a wrapper where the content must be manipulated by lenses (in spirit: `type 'a t = A : 'r * ('r, 'r, 'a, 'a) Lun.t -> 'a t`) but I wanted to allow pattern matching on it. So I wrote something that turn `match%lensed x with P[a;b] -> E` into `match view x with P[_;_] -> let a = ... [%lun? P[x;_]] and b = ... [%lun? P[_,x]] in E`, which allow to retrieve  the lense for all variables in a pattern, and insert them automatically. This might have some general usefulness, if you are interested.